### PR TITLE
feat: 전역 예외 핸들러 추가

### DIFF
--- a/common/src/main/kotlin/org/kkeunkkeun/pregen/common/presentation/ErrorResponse.kt
+++ b/common/src/main/kotlin/org/kkeunkkeun/pregen/common/presentation/ErrorResponse.kt
@@ -1,0 +1,25 @@
+package org.kkeunkkeun.pregen.common.presentation
+
+import org.springframework.web.context.request.RequestContextHolder
+import org.springframework.web.context.request.ServletRequestAttributes
+import java.time.LocalDateTime
+
+
+data class ErrorResponse(
+    val timestamp: LocalDateTime,
+    val error: String,
+    val code: Int,
+    val message: String?,
+    val path: String,
+) {
+
+    companion object {
+
+        fun from(pregenException: PregenException, path: String): ErrorResponse {
+            val timestamp = LocalDateTime.now()
+            val errorStatus = pregenException.errorStatus
+
+            return ErrorResponse(timestamp, errorStatus.name, errorStatus.errorCode, pregenException.message, path)
+        }
+    }
+}

--- a/common/src/main/kotlin/org/kkeunkkeun/pregen/common/presentation/ErrorStatus.kt
+++ b/common/src/main/kotlin/org/kkeunkkeun/pregen/common/presentation/ErrorStatus.kt
@@ -1,0 +1,14 @@
+package org.kkeunkkeun.pregen.common.presentation
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatus.NOT_FOUND
+
+enum class ErrorStatus(
+    val errorCode: Int,
+    val message: String?,
+    val status: HttpStatus,
+) {
+
+    /* 404 */
+    DATA_NOT_FOUND(40401, "리소스를 찾을 수 없습니다.", NOT_FOUND)
+}

--- a/common/src/main/kotlin/org/kkeunkkeun/pregen/common/presentation/PregenException.kt
+++ b/common/src/main/kotlin/org/kkeunkkeun/pregen/common/presentation/PregenException.kt
@@ -1,0 +1,16 @@
+package org.kkeunkkeun.pregen.common.presentation
+
+import org.springframework.http.ResponseEntity
+
+class PregenException(
+    val errorStatus: ErrorStatus,
+    message: String? = null,
+): RuntimeException(message) {
+
+    fun toResponseEntity(path: String): ResponseEntity<ErrorResponse> {
+        return ResponseEntity.status(this.errorStatus.status)
+            .body(ErrorResponse.from(this, path))
+    }
+
+    constructor(errorStatus: ErrorStatus): this(errorStatus, errorStatus.message)
+}

--- a/common/src/main/kotlin/org/kkeunkkeun/pregen/common/presentation/PregenExceptionHandler.kt
+++ b/common/src/main/kotlin/org/kkeunkkeun/pregen/common/presentation/PregenExceptionHandler.kt
@@ -1,0 +1,20 @@
+package org.kkeunkkeun.pregen.common.presentation
+
+import jakarta.servlet.http.HttpServletRequest
+import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class PregenExceptionHandler {
+
+    private val log = LoggerFactory.getLogger(this.javaClass)!!
+
+    @ExceptionHandler(PregenException::class)
+    fun handlePregenException(request: HttpServletRequest, exception: PregenException): ResponseEntity<ErrorResponse> {
+        log.error("pregen exception occurred!!", exception)
+
+        return exception.toResponseEntity(request.requestURI)
+    }
+}


### PR DESCRIPTION
# Description
- 설계한 예외 정책대로 전역 예외처리 핸들러를 추가합니다.
  - 아래와 같은 형태로 에러 메시지가 제공됩니다.
      ```json
      {
        "timestamp": "2019-01-17T16:12:45.977+0000",
        "error": "DATA_NOT_FOUND",
		    "code": 40401,
        "message": "Error processing the request!",
        "path": "/my-endpoint-with-exceptions"
      }
# Issue
- resolve #11 