### PR TITLE
[#15] 토큰 전달 방식 쿠키로 수정

### DIFF
--- a/account-api/src/main/kotlin/org/kkeunkkeun/pregen/account/infrastructure/config/SecurityConfig.kt
+++ b/account-api/src/main/kotlin/org/kkeunkkeun/pregen/account/infrastructure/config/SecurityConfig.kt
@@ -54,8 +54,9 @@ class SecurityConfig(
                     .successHandler(oAuth2LoginSuccessHandler)
                     .failureHandler(oAuth2LoginFailureHandler)
             }
+            .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter::class.java)
 
-        return http.addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter::class.java).build()
+        return http.build()
     }
 
     @Bean

--- a/account-api/src/main/kotlin/org/kkeunkkeun/pregen/account/infrastructure/security/jwt/JwtAuthFilter.kt
+++ b/account-api/src/main/kotlin/org/kkeunkkeun/pregen/account/infrastructure/security/jwt/JwtAuthFilter.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpStatus
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
 import org.springframework.util.StringUtils
@@ -42,7 +43,7 @@ class JwtAuthFilter(
             val objectMapper = ObjectMapper()
             response.contentType = "application/json; charset=utf-8"
             response.characterEncoding = "UTF-8"
-            response.status = HttpServletResponse.SC_UNAUTHORIZED
+            response.status = HttpStatus.UNAUTHORIZED.value()
             response.writer.write(
                 objectMapper.writeValueAsString(mapOf("message" to e.message))
             )

--- a/account-api/src/main/kotlin/org/kkeunkkeun/pregen/account/infrastructure/security/jwt/JwtTokenUtil.kt
+++ b/account-api/src/main/kotlin/org/kkeunkkeun/pregen/account/infrastructure/security/jwt/JwtTokenUtil.kt
@@ -2,6 +2,8 @@ package org.kkeunkkeun.pregen.account.infrastructure.security.jwt
 
 import io.jsonwebtoken.*
 import io.jsonwebtoken.security.Keys
+import jakarta.servlet.http.Cookie
+import jakarta.servlet.http.HttpServletRequest
 import org.kkeunkkeun.pregen.account.domain.AccountRole
 import org.kkeunkkeun.pregen.account.infrastructure.AccountRepository
 import org.kkeunkkeun.pregen.account.infrastructure.config.AccountProperties
@@ -31,14 +33,9 @@ class JwtTokenUtil(
         secretKey = Keys.hmacShaKeyFor(decodedKey)
     }
 
-    fun extractToken(token: String?): String? {
-        if (token != null) {
-            if (!token.startsWith("Bearer ")) {
-                throw IllegalArgumentException("Invalid token")
-            }
-            return token.split(" ")[1].trim()
-        }
-        return null;
+    fun getTokenFromCookie(tokenType: String, request: HttpServletRequest): String {
+        val jwtCookie = request.cookies.find { it.name == tokenType }  ?: throw IllegalArgumentException("쿠키에 토큰이 존재하지 않습니다.")
+        return jwtCookie.value
     }
 
     fun generateToken(email: String, role: String): JwtTokenResponse {
@@ -47,10 +44,8 @@ class JwtTokenUtil(
 
         val token = refreshTokenService.saveTokenInfo(email, accessToken, refreshToken)
         return JwtTokenResponse(
-                    accessToken = accessToken,
-                    refreshToken = refreshToken,
-                    tokenType = "Bearer",
-                    expiresIn = accountProperties.jwt.accessExpirationTime,
+                    accessToken = token.accessToken,
+                    refreshToken = token.refreshToken,
                 )
     }
 
@@ -87,7 +82,7 @@ class JwtTokenUtil(
             val claims = Jwts.parserBuilder()
                 .setSigningKey(secretKey)
                 .build()
-                .parseClaimsJws(token.removePrefix("Bearer ").trim())
+                .parseClaimsJws(token)
             return claims.body.expiration.after(Date())
         } catch (e: ExpiredJwtException) {
             throw IllegalArgumentException("Expired access token")
@@ -97,6 +92,24 @@ class JwtTokenUtil(
                 else -> throw e
             }
         }
+    }
+
+    fun generateTokenCookie(tokenType: String, jwtToken: String): Cookie {
+        return Cookie(tokenType, jwtToken).apply {
+            path = "/"
+            isHttpOnly = true // 요청 외 클라이언트에서 쿠키를 읽을 수 없도록 설정
+            secure = false // 아직 https 적용 안함. 이후에 적용하면 true로 변경
+            maxAge = (getTokenExpirationTime(jwtToken).time - System.currentTimeMillis() / 1000).toInt()
+        }
+    }
+
+    fun getTokenExpirationTime(token: String): Date {
+        return Jwts.parserBuilder()
+            .setSigningKey(secretKey)
+            .build()
+            .parseClaimsJws(token)
+            .body
+            .expiration
     }
 
     fun getAuthentication(accessToken: String): Authentication {
@@ -114,7 +127,7 @@ class JwtTokenUtil(
         return Jwts.parserBuilder()
             .setSigningKey(secretKey)
             .build()
-            .parseClaimsJws(token.removePrefix("Bearer ").trim())
+            .parseClaimsJws(token)
             .body
             .subject
     }
@@ -123,7 +136,7 @@ class JwtTokenUtil(
         return Jwts.parserBuilder()
             .setSigningKey(secretKey)
             .build()
-            .parseClaimsJws(token.removePrefix("Bearer ").trim())
+            .parseClaimsJws(token)
             .body
             .get("role", String::class.java)
     }

--- a/account-api/src/main/kotlin/org/kkeunkkeun/pregen/account/infrastructure/security/jwt/dto/JwtTokenResponse.kt
+++ b/account-api/src/main/kotlin/org/kkeunkkeun/pregen/account/infrastructure/security/jwt/dto/JwtTokenResponse.kt
@@ -3,6 +3,4 @@ package org.kkeunkkeun.pregen.account.infrastructure.security.jwt.dto
 data class JwtTokenResponse(
     val accessToken: String,
     val refreshToken: String,
-    val tokenType: String,
-    val expiresIn: Long,
 )

--- a/account-api/src/main/kotlin/org/kkeunkkeun/pregen/account/presentation/AccountController.kt
+++ b/account-api/src/main/kotlin/org/kkeunkkeun/pregen/account/presentation/AccountController.kt
@@ -1,12 +1,13 @@
 package org.kkeunkkeun.pregen.account.presentation
 
 import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
 import jakarta.validation.Valid
 import org.kkeunkkeun.pregen.account.domain.dto.AccountResponse
 import org.kkeunkkeun.pregen.account.domain.dto.AccountUpdateRequest
-import org.kkeunkkeun.pregen.account.infrastructure.security.jwt.dto.JwtTokenResponse
 import org.kkeunkkeun.pregen.account.service.AccountService
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.Authentication
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.*
 
@@ -16,20 +17,27 @@ class AccountController(
     private val accountService: AccountService,
 ) {
 
+    @PostMapping("/login")
+    fun login(response: HttpServletResponse, authentication: Authentication): ResponseEntity<HttpServletResponse> {
+        return ResponseEntity.ok().body(accountService.loginAccount(response, authentication))
+    }
+
     @PostMapping("/logout")
     fun logout(request: HttpServletRequest): ResponseEntity<Unit> {
-        accountService.logoutAccount(request)
+        val authentication = SecurityContextHolder.getContext().authentication
+        accountService.logoutAccount(request, authentication)
         return ResponseEntity.ok().build()
     }
 
     @GetMapping("/reissue")
-    fun reissueToken(request: HttpServletRequest): ResponseEntity<JwtTokenResponse> {
-        return ResponseEntity.ok().body(accountService.reIssueToken(request))
+    fun reissueToken(request: HttpServletRequest, response: HttpServletResponse): ResponseEntity<HttpServletResponse> {
+        return ResponseEntity.ok().body(accountService.reIssueToken(request, response))
     }
 
     @GetMapping("/revoke")
     fun revokeToken(request: HttpServletRequest): ResponseEntity<Unit> {
-        accountService.revokeAccount(request)
+        val email = SecurityContextHolder.getContext().authentication.name
+        accountService.revokeAccount(request, email)
         return ResponseEntity.ok().build()
     }
 

--- a/account-api/src/main/kotlin/org/kkeunkkeun/pregen/account/presentation/AccountController.kt
+++ b/account-api/src/main/kotlin/org/kkeunkkeun/pregen/account/presentation/AccountController.kt
@@ -7,7 +7,6 @@ import org.kkeunkkeun.pregen.account.domain.dto.AccountResponse
 import org.kkeunkkeun.pregen.account.domain.dto.AccountUpdateRequest
 import org.kkeunkkeun.pregen.account.service.AccountService
 import org.springframework.http.ResponseEntity
-import org.springframework.security.core.Authentication
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.*
 
@@ -16,11 +15,6 @@ import org.springframework.web.bind.annotation.*
 class AccountController(
     private val accountService: AccountService,
 ) {
-
-    @PostMapping("/login")
-    fun login(response: HttpServletResponse, authentication: Authentication): ResponseEntity<HttpServletResponse> {
-        return ResponseEntity.ok().body(accountService.loginAccount(response, authentication))
-    }
 
     @PostMapping("/logout")
     fun logout(request: HttpServletRequest): ResponseEntity<Unit> {

--- a/account-api/src/main/kotlin/org/kkeunkkeun/pregen/account/service/AccountService.kt
+++ b/account-api/src/main/kotlin/org/kkeunkkeun/pregen/account/service/AccountService.kt
@@ -19,7 +19,6 @@ import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.MediaType
 import org.springframework.security.core.Authentication
-import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.client.RestTemplate
@@ -49,44 +48,6 @@ class AccountService(
             socialAccessToken = accessToken
         )
         return accountRepository.save(account)
-    }
-
-    @Transactional
-    fun loginAccount(response: HttpServletResponse, authentication: Authentication): HttpServletResponse {
-        val oAuthUser: OAuth2User = authentication.principal as OAuth2User
-
-        val email = oAuthUser.attributes["email"] as? String ?: throw IllegalArgumentException("email이 존재하지 않습니다.")
-        val provider = oAuthUser.attributes["provider"] as? String ?: throw IllegalArgumentException("provider가 존재하지 않습니다.")
-        val isExist: Boolean = oAuthUser.attributes["exist"] as? Boolean ?: throw IllegalArgumentException("exist가 존재하지 않습니다.")
-        val accessToken = oAuthUser.attributes["accessToken"] as? String ?: throw IllegalArgumentException("accessToken이 존재하지 않습니다.")
-        val nickName = oAuthUser.attributes["nickName"] as? String ?: generatedNickName()
-        val role = oAuthUser.authorities.stream().findFirst().orElseThrow { throw IllegalArgumentException() }.authority
-
-        if (isExist) {
-            val account = accountRepository.findByEmail(email) ?: throw IllegalArgumentException("존재하지 않는 계정입니다.")
-            account.updateAccessToken(accessToken)
-            account.updateEmail(email)
-            refreshTokenService.deleteById(email)
-
-            val jwtToken = jwtTokenUtil.generateToken(account.email, account.role.value)
-            val accessTokenCookie = jwtTokenUtil.generateTokenCookie("accessToken", jwtToken.accessToken)
-            val refreshTokenCookie = jwtTokenUtil.generateTokenCookie("refreshToken", jwtToken.refreshToken)
-
-            response.addCookie(accessTokenCookie)
-            response.addCookie(refreshTokenCookie)
-            response.sendRedirect("/")
-        } else {
-            val account = signUp(email, nickName, provider, role, accessToken)
-            val jwtToken = jwtTokenUtil.generateToken(account.email, account.role.value)
-            val accessTokenCookie = jwtTokenUtil.generateTokenCookie("accessToken", jwtToken.accessToken)
-            val refreshTokenCookie = jwtTokenUtil.generateTokenCookie("refreshToken", jwtToken.refreshToken)
-
-            response.addCookie(accessTokenCookie)
-            response.addCookie(refreshTokenCookie)
-            response.sendRedirect("/")
-        }
-
-        return response
     }
 
     @Transactional

--- a/account-api/src/main/resources/application.yml
+++ b/account-api/src/main/resources/application.yml
@@ -51,7 +51,7 @@ spring:
           kakao:
             client-id: ENC(/NVz3t1aoMGO4L9F9MI017vxf8KcHfo3y/+xMWKfUAg1LcGiqMY6l0NvNXXPjKJC)
             client-secret: ENC(+c7I7VG9cIym6iwPEnZKIzpkTVmhDB/SbHBy5RO2fGSse9r7pauDqfzRrSrvnmv1)
-            redirect-uri: http://localhost:8080/login/oauth2/code/kakao
+            redirect-uri: http://localhost:3000/login/oauth2/code/kakao
             client-authentication-method: client_secret_post
             authorization-grant-type: authorization_code
             client-name: kakao
@@ -63,7 +63,7 @@ spring:
           naver:
             client-id: ENC(lPu7dZZ8/5Nw+58vtKCPkVqWFFOavr41eEQ4iTZHeAM=)
             client-secret: ENC(C3vESb/5wp0oAS5Xv0+31pE002otp/aN)
-            redirect-uri: http://localhost:8080/login/oauth2/code/naver
+            redirect-uri: http://localhost:3000/login/oauth2/code/naver
             clientAuthenticationMethod: client_secret_post
             authorization-grant-type: authorization_code
             client-name: naver

--- a/account-api/src/main/resources/application.yml
+++ b/account-api/src/main/resources/application.yml
@@ -51,7 +51,7 @@ spring:
           kakao:
             client-id: ENC(/NVz3t1aoMGO4L9F9MI017vxf8KcHfo3y/+xMWKfUAg1LcGiqMY6l0NvNXXPjKJC)
             client-secret: ENC(+c7I7VG9cIym6iwPEnZKIzpkTVmhDB/SbHBy5RO2fGSse9r7pauDqfzRrSrvnmv1)
-            redirect-uri: http://localhost:3000/login/oauth2/code/kakao
+            redirect-uri: http://localhost:8080/login/oauth2/code/kakao
             client-authentication-method: client_secret_post
             authorization-grant-type: authorization_code
             client-name: kakao
@@ -63,7 +63,7 @@ spring:
           naver:
             client-id: ENC(lPu7dZZ8/5Nw+58vtKCPkVqWFFOavr41eEQ4iTZHeAM=)
             client-secret: ENC(C3vESb/5wp0oAS5Xv0+31pE002otp/aN)
-            redirect-uri: http://localhost:3000/login/oauth2/code/naver
+            redirect-uri: http://localhost:8080/login/oauth2/code/naver
             clientAuthenticationMethod: client_secret_post
             authorization-grant-type: authorization_code
             client-name: naver

--- a/common/src/main/resources/application-common.yml
+++ b/common/src/main/resources/application-common.yml
@@ -1,5 +1,5 @@
 custom:
-  baseUrl: http://localhost:8080
+  base-url: http://localhost:8080
   redis:
     host: localhost
     port: 6379
@@ -13,7 +13,7 @@ spring:
     activate:
       on-profile: prod
 custom:
-  base-baseUrl: http://localhost:8080
+  base-url: http://localhost:8080
   redis:
     host: localhost
     port: 6379


### PR DESCRIPTION
# Issue
- #15 

# Issue 주요 내용
- jwt 전달 방식을 json에서 cookie로 변경하였습니다.
- 이후 인가/인증 방식을 쿠키에서 토큰값을 가져와서 검증하는 것으로 로직이 변경되었습니다.
- 소셜로그인 흐름이 백엔드 중심에서 프론트엔드 -> 백엔드 흐름으로 변경되었습니다.
### 기존 흐름
    프론트엔드 로그인 요청 -> 백엔드 redirect url로 인가코드 전송 -> jwt 토큰 발급 후, 프론트엔드로 쿠키 전송
### 현재 흐름
    프론트엔드 로그인 요청 -> 프론트엔드 redirect url로 인가코드 전송 -> 백엔드 로그인 api로 인가코드 전송 -> jwt 토큰 발급 후, 프론트엔드로 쿠키 전송
- 이렇게 흐름이 변경된 이유는 다음과 같은 단점을 없애기 위함입니다.
    - 모든 요청은 프론트엔드를 통해서 받기 때문에 기존 흐름으로 하면 요청은 프론트엔드에서 왔지만 응답은 백엔드에서 받기 때문에 다른 도메인, 다른 포트에서 이루어지므로, CORS 정책을 준수하기 위해 프론트엔드에서 인가코드를 받는것으로 하고 요청을 허용해야합니다.
    - 안드로이드와 같이 Redirect 할 수 없는 모바일 환경에서는 사용할 수 없다.
- 따라서 정책 준수와 확장성을 위해 다음 흐름으로 수정했습니다.
- 하지만 아직 처음 시도하는 방법 이라 코드를 올리자마자 될지는 잘모르겠습니다. 이후 프론트엔드 개발자분과 테스트 후에 코드를 개선하겠습니다.

resolved #15 
