### PR TITLE
[#20] 로그인 응답 redirect 요청 해제

### DIFF
--- a/account-api/src/main/kotlin/org/kkeunkkeun/pregen/account/infrastructure/security/oauth/OAuth2Attribute.kt
+++ b/account-api/src/main/kotlin/org/kkeunkkeun/pregen/account/infrastructure/security/oauth/OAuth2Attribute.kt
@@ -20,14 +20,14 @@ class OAuth2Attribute(
 
         private fun ofKakao(provider: String, attributeKey: String, attributes: Map<String, Any>, randomNickName: String): OAuth2Attribute {
             val kakaoAccount = attributes["kakao_account"] as Map<String, Any>
-            val profile = kakaoAccount["profile"] as Map<String, Any>
+            val profile = kakaoAccount["profile"] as? Map<String, Any>?
 
             return OAuth2Attribute(
                 email = kakaoAccount["email"] as? String ?: throw IllegalArgumentException("email이 존재하지 않습니다."),
                 provider = provider,
                 attributes = kakaoAccount,
                 attributeKey = attributeKey,
-                nickName = profile.get("nickname") as? String ?: randomNickName,
+                nickName = profile?.get("nickname") as? String ?: randomNickName,
             )
         }
 

--- a/account-api/src/main/kotlin/org/kkeunkkeun/pregen/account/infrastructure/security/oauth/OAuth2LoginSuccessHandler.kt
+++ b/account-api/src/main/kotlin/org/kkeunkkeun/pregen/account/infrastructure/security/oauth/OAuth2LoginSuccessHandler.kt
@@ -5,6 +5,7 @@ import jakarta.servlet.http.HttpServletResponse
 import org.kkeunkkeun.pregen.account.infrastructure.security.jwt.JwtTokenUtil
 import org.kkeunkkeun.pregen.account.infrastructure.security.jwt.refreshtoken.RefreshTokenService
 import org.kkeunkkeun.pregen.account.service.AccountService
+import org.springframework.http.HttpStatus
 import org.springframework.security.core.Authentication
 import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler
@@ -41,7 +42,7 @@ class OAuth2LoginSuccessHandler(
 
             response.addCookie(accessTokenCookie)
             response.addCookie(refreshTokenCookie)
-            response.sendRedirect("/")
+            response.status = HttpStatus.OK.value()
         } else {
             // 회원이 존재하지 않는다면, 회원가입 후 token 발행
             val account = accountService.signUp(email, nickName, provider, role, accessToken)
@@ -51,7 +52,7 @@ class OAuth2LoginSuccessHandler(
 
             response.addCookie(accessTokenCookie)
             response.addCookie(refreshTokenCookie)
-            response.sendRedirect("/")
+            response.status = HttpStatus.OK.value()
         }
     }
 }


### PR DESCRIPTION
## Motivation
- 로그인 성공 응답 주소를 수정합니다.
- kakao 로그인 에러를 개선합니다.

## Key Changes
- `AuthLoginSuccessHandler`에서 response가 redirect되지 않고, 그대로 status 200과 함께 반환하는 것으로 수정합니다.
- kakao 로그인 요청시에 선택 조건인 닉네임을 선택하지 않았을 때, 반환값에 profile 키가 존재하지 않게 되는데,
- profile의 키를 강제로 가져오려고 해서 `NullPointerException`이 발생하고 있었습니다. null일 경우, randomNick으로 초기화되도록 수정했습니다.

## To Reviewers
- 로그인 흐름으로 일을 크게 벌리지 않았나 생각되네용 😅

## Linked Issue
- resolved #20 
