### PR TITLE
[#27] 회원 인증 로직 예외 개선

### DIFF
--- a/account-api/src/main/kotlin/org/kkeunkkeun/pregen/account/infrastructure/config/SecurityConfig.kt
+++ b/account-api/src/main/kotlin/org/kkeunkkeun/pregen/account/infrastructure/config/SecurityConfig.kt
@@ -36,10 +36,9 @@ class SecurityConfig(
             .authorizeHttpRequests {
                 auth -> auth
                     .requestMatchers(
-                        "/api/account/login",
-                        "/api/accounts/login/**",
-                        "/api/accounts/reissue").permitAll()
-                    .anyRequest().authenticated()
+                        "/api/accounts/login",
+                        "/api/accounts/login/**").hasRole("ANONYMOUS")
+                    .anyRequest().hasRole("MEMBER")
             }
             .headers {
                 headers -> headers.addHeaderWriter(

--- a/account-api/src/main/kotlin/org/kkeunkkeun/pregen/account/infrastructure/security/jwt/JwtAuthFilter.kt
+++ b/account-api/src/main/kotlin/org/kkeunkkeun/pregen/account/infrastructure/security/jwt/JwtAuthFilter.kt
@@ -4,6 +4,12 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import org.kkeunkkeun.pregen.account.infrastructure.security.jwt.refreshtoken.RefreshTokenService
+import org.kkeunkkeun.pregen.common.presentation.ErrorResponse
+import org.kkeunkkeun.pregen.common.presentation.ErrorStatus
+import org.kkeunkkeun.pregen.common.presentation.PregenException
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
@@ -13,7 +19,12 @@ import org.springframework.web.filter.OncePerRequestFilter
 @Component
 class JwtAuthFilter(
     private val jwtTokenUtil: JwtTokenUtil,
+    private val objectMapper: ObjectMapper,
+
+    private val refreshTokenService: RefreshTokenService,
 ): OncePerRequestFilter() {
+
+    val log: Logger = LoggerFactory.getLogger(this::class.java)
 
     override fun doFilterInternal(
         request: HttpServletRequest,
@@ -21,33 +32,71 @@ class JwtAuthFilter(
         filterChain: FilterChain
     ) {
         try {
-            if (request.requestURI.startsWith("/api/accounts/login") || request.requestURI.startsWith("/api/accounts/reissue")) {
+            if (request.requestURI.contains("login")) {
+                val isToken = jwtTokenUtil.checkTokenFromCookie("accessToken", request)
+                if (isToken) {
+                    throw PregenException(ErrorStatus.UNAUTHORIZED, "이미 로그인된 상태입니다.")
+                }
                 filterChain.doFilter(request, response)
                 return
             }
 
-            val accessToken = jwtTokenUtil.getTokenFromCookie("accessToken", request)
-            if (!StringUtils.hasText(accessToken)) {
+            if (request.requestURI.contains("reissue")) {
+                val refreshToken = jwtTokenUtil.getTokenFromCookie("refreshToken", request)
+                if (!StringUtils.hasText(refreshToken)) {
+                    throw PregenException(ErrorStatus.UNAUTHORIZED, "헤더에 토큰이 존재하지 않습니다.")
+                }
+
+                if (!jwtTokenUtil.verifyToken(refreshToken) && !refreshTokenService.verifyToken("refreshToken", refreshToken)) {
+                    throw PregenException(ErrorStatus.INVALID_TOKEN, "유효하지 않은 토큰입니다.")
+                } else {
+                    val authentication = jwtTokenUtil.getAuthentication(refreshToken)
+                    SecurityContextHolder.getContext().authentication = authentication
+                }
+
                 filterChain.doFilter(request, response)
                 return
-            }
-
-            if (!jwtTokenUtil.verifyToken(accessToken)) {
-                throw IllegalArgumentException("유효하지 않은 토큰입니다.")
             } else {
-                val authentication = jwtTokenUtil.getAuthentication(accessToken)
-                SecurityContextHolder.getContext().authentication = authentication
-            }
+                val accessToken = jwtTokenUtil.getTokenFromCookie("accessToken", request)
+                if (!StringUtils.hasText(accessToken)) {
+                    throw PregenException(ErrorStatus.UNAUTHORIZED, "헤더에 토큰이 존재하지 않습니다.")
+                }
 
-            filterChain.doFilter(request, response)
+                if (!jwtTokenUtil.verifyToken(accessToken) && !refreshTokenService.verifyToken("accessToken", accessToken)) {
+                    throw PregenException(ErrorStatus.INVALID_TOKEN, "유효하지 않은 토큰입니다.")
+                } else {
+                    val authentication = jwtTokenUtil.getAuthentication(accessToken)
+                    SecurityContextHolder.getContext().authentication = authentication
+                }
+
+                filterChain.doFilter(request, response)
+            }
+        } catch (e: PregenException) {
+            log.error("Filter error: ${e.message}")
+            handleException(request, response, e)
         } catch (e: Exception) {
-            // 에러 발생 시, 클라이언트에게 에러 메시지를 전달. 이후 커스텀 예외 response로 변경
-            val objectMapper = ObjectMapper()
-            response.contentType = "application/json; charset=utf-8"
+            log.error("Filter error: ${e.message}")
+            handleException(request, response, e, "인증 과정에서 예외가 발생했습니다.")
+        }
+    }
+
+    private fun handleException(request: HttpServletRequest, response: HttpServletResponse, e: Exception, message: String? = null) {
+        if (e is PregenException) {
+            val errorResponse = ErrorResponse.from(e, request.requestURI)
+            response.status = e.errorStatus.status.value()
+            response.contentType = "application/json"
             response.characterEncoding = "UTF-8"
+            response.outputStream.write(objectMapper.writeValueAsBytes(errorResponse))
+        } else {
             response.status = HttpStatus.UNAUTHORIZED.value()
+            response.contentType = "application/json"
+            response.characterEncoding = "UTF-8"
+            val errorResponse = ErrorResponse.from(
+                PregenException(ErrorStatus.UNAUTHORIZED, message ?: "예외가 발생했습니다."),
+                request.requestURI
+            )
             response.outputStream.write(
-                objectMapper.writeValueAsBytes(mapOf("message" to e.message))
+                objectMapper.writeValueAsBytes(errorResponse)
             )
         }
     }

--- a/account-api/src/main/kotlin/org/kkeunkkeun/pregen/account/infrastructure/security/jwt/JwtTokenUtil.kt
+++ b/account-api/src/main/kotlin/org/kkeunkkeun/pregen/account/infrastructure/security/jwt/JwtTokenUtil.kt
@@ -34,20 +34,22 @@ class JwtTokenUtil(
         secretKey = Keys.hmacShaKeyFor(decodedKey)
     }
 
+    fun checkTokenFromCookie(tokenType: String, request: HttpServletRequest): Boolean {
+        val cookieHeader = request.getHeader("cookie") ?: return false
+        return cookieHeader.contains(tokenType)
+    }
+
     fun getTokenFromCookie(tokenType: String, request: HttpServletRequest): String {
-        // 'cookie' 헤더 값을 가져옵니다.
         val cookieHeader = request.getHeader("cookie")
             ?: throw IllegalArgumentException("쿠키 헤더가 요청에 존재하지 않습니다.")
 
-        // 쿠키 헤더에서 토큰 타입에 해당하는 값을 파싱
         val tokenValue = cookieHeader
             .split("; ")
-            .map { it.split("=") } // 각 쿠키를 "=" 기호를 사용하여 키와 값으로 분리
-            .firstOrNull { it.first() == tokenType } // 토큰 타입에 해당하는 쌍을 찾음
+            .map { it.split("=") }
+            .firstOrNull { it.first() == tokenType }
             ?.let { it.getOrNull(1) ?: throw IllegalArgumentException("쿠키 값이 '$tokenType'로 올바르게 시작하지 않습니다.") }
             ?: throw IllegalArgumentException("$tokenType 토큰이 쿠키 값에 존재하지 않습니다.")
 
-        // tokenType에 해당하는 토큰 값을 반환합니다.
         return tokenValue
     }
 

--- a/account-api/src/main/kotlin/org/kkeunkkeun/pregen/account/infrastructure/security/jwt/refreshtoken/RefreshTokenService.kt
+++ b/account-api/src/main/kotlin/org/kkeunkkeun/pregen/account/infrastructure/security/jwt/refreshtoken/RefreshTokenService.kt
@@ -10,6 +10,7 @@ class RefreshTokenService(
 ) {
 
     fun saveTokenInfo(email: String, accessToken: String, refreshToken: String): RefreshToken {
+        refreshTokenRepository.findById(email).ifPresent { refreshTokenRepository.deleteById(email) }
         val savedToken = refreshTokenRepository.save(
             RefreshToken(
                 id = email,
@@ -18,6 +19,14 @@ class RefreshTokenService(
             )
         )
         return savedToken
+    }
+
+    fun verifyToken(tokenType: String, refreshToken: String): Boolean {
+        return when (tokenType) {
+            "accessToken" -> refreshTokenRepository.findByAccessToken(refreshToken) != null
+            "refreshToken" -> refreshTokenRepository.findByRefreshToken(refreshToken) != null
+            else -> false
+        }
     }
 
     fun deleteById(id: String) {

--- a/account-api/src/main/kotlin/org/kkeunkkeun/pregen/account/infrastructure/security/jwt/refreshtoken/RefreshTokenService.kt
+++ b/account-api/src/main/kotlin/org/kkeunkkeun/pregen/account/infrastructure/security/jwt/refreshtoken/RefreshTokenService.kt
@@ -21,10 +21,17 @@ class RefreshTokenService(
         return savedToken
     }
 
-    fun verifyToken(tokenType: String, refreshToken: String): Boolean {
+    fun verifyToken(tokenType: String, token: String): Boolean {
         return when (tokenType) {
-            "accessToken" -> refreshTokenRepository.findByAccessToken(refreshToken) != null
-            "refreshToken" -> refreshTokenRepository.findByRefreshToken(refreshToken) != null
+            "accessToken" -> {
+                val findToken = refreshTokenRepository.findByAccessToken(token)
+                findToken != null && findToken.accessToken == token
+            }
+            "refreshToken" -> {
+                val findToken = refreshTokenRepository.findByAccessToken(token)
+                findToken != null && findToken.refreshToken == token
+
+            }
             else -> false
         }
     }

--- a/account-api/src/main/kotlin/org/kkeunkkeun/pregen/account/infrastructure/security/jwt/refreshtoken/RefreshTokenService.kt
+++ b/account-api/src/main/kotlin/org/kkeunkkeun/pregen/account/infrastructure/security/jwt/refreshtoken/RefreshTokenService.kt
@@ -30,7 +30,6 @@ class RefreshTokenService(
             "refreshToken" -> {
                 val findToken = refreshTokenRepository.findByAccessToken(token)
                 findToken != null && findToken.refreshToken == token
-
             }
             else -> false
         }

--- a/account-api/src/main/kotlin/org/kkeunkkeun/pregen/account/oauth/service/OAuthService.kt
+++ b/account-api/src/main/kotlin/org/kkeunkkeun/pregen/account/oauth/service/OAuthService.kt
@@ -69,20 +69,20 @@ class OAuthService(
     }
 
     fun sendRevokeRequest(socialAuthToken: SocialAuthToken, provider: SocialProvider) {
-        verifySocialToken(socialAuthToken, provider)
+        val reissueAuthToken = verifyAndReissueSocialToken(socialAuthToken, provider)
         val httpHeaders = HttpHeaders()
         httpHeaders.contentType = MediaType.APPLICATION_FORM_URLENCODED
 
         val revokeUrl = when (provider) {
             SocialProvider.KAKAO -> {
-                httpHeaders.setBearerAuth(socialAuthToken.socialAccessToken)
+                httpHeaders.setBearerAuth(reissueAuthToken.socialAccessToken)
                 socialProperties.kakaoRevokeUrl()
             }
             SocialProvider.NAVER -> {
-                socialProperties.naverRevokeUrl(socialAuthToken.socialAccessToken, SocialProvider.NAVER.value)
+                socialProperties.naverRevokeUrl(reissueAuthToken.socialAccessToken, SocialProvider.NAVER.value)
             }
             SocialProvider.GOOGLE -> {
-                socialProperties.googleRevokeUrl(socialAuthToken.socialAccessToken)
+                socialProperties.googleRevokeUrl(reissueAuthToken.socialAccessToken)
             }
         }
         val httpEntity: HttpEntity<String> = HttpEntity(revokeUrl, httpHeaders)
@@ -93,7 +93,7 @@ class OAuthService(
         }
     }
 
-    fun verifySocialToken(socialAuthToken: SocialAuthToken, provider: SocialProvider): SocialAuthToken {
+    fun verifyAndReissueSocialToken(socialAuthToken: SocialAuthToken, provider: SocialProvider): SocialAuthToken {
         val now = LocalDateTime.now()
         val oauthTokenResponse: OauthTokenResponse
 

--- a/account-api/src/main/kotlin/org/kkeunkkeun/pregen/account/presentation/AccountController.kt
+++ b/account-api/src/main/kotlin/org/kkeunkkeun/pregen/account/presentation/AccountController.kt
@@ -21,20 +21,23 @@ class AccountController(
     fun login(
         @NotNull @RequestParam("code") code: String,
         @NotNull @RequestParam("provider") provider: String,
-        @RequestParam("state") state: String? = null,
+        @RequestParam("state") state: String?,
         response: HttpServletResponse): ResponseEntity<Any> {
-        return ResponseEntity.ok().body(accountService.loginAccount(code, provider, state, response))
-    }
-
-    @GetMapping("/reissue")
-    fun reissueToken(request: HttpServletRequest, response: HttpServletResponse): ResponseEntity<Unit> {
-        accountService.reIssueToken(request, response)
+        accountService.loginAccount(code, provider, state, response)
         return ResponseEntity.ok().build()
     }
 
-    @PostMapping("/logout")
-    fun logout(request: HttpServletRequest): ResponseEntity<Unit> {
-        accountService.logoutAccount(request)
+    @GetMapping("/reissue")
+    fun reissueToken(request: HttpServletRequest, response: HttpServletResponse,
+                     @AccountEmail email: String): ResponseEntity<Unit> {
+        accountService.reIssueToken(request, response, email)
+        return ResponseEntity.ok().build()
+    }
+
+    @GetMapping("/logout")
+    fun logout(request: HttpServletRequest,
+               @AccountEmail email: String): ResponseEntity<Unit> {
+        accountService.logoutAccount(request, email)
         return ResponseEntity.ok().build()
     }
 


### PR DESCRIPTION
## Motivation
- 회원의 인증 로직에 발생하는 예외를 핸들링합니다.
- 네이버 등 소셜로그인을 대응할 수 있도록 로직을 개선합니다.

## Key Changes
- 쿠키를 `header.cookies`에서 가져올 수 없어 header에 다른 cookie라는 공간에 넣어 토큰을 받아왔습니다.
- 네이버 등 소셜로그인 과정을 대응할 수 있도록 개선했습니다.
- 토큰 검증과정 중, redis에 저장되는 토큰도 검증할 수있도록 추가했습니다.

## To Reviewers
- 수고많으십니다!

## Linked Issue
- resolved #27 
